### PR TITLE
Extend put_item to allow conditions

### DIFF
--- a/src/darcy.erl
+++ b/src/darcy.erl
@@ -419,7 +419,7 @@ make_put_request(TableName, Item,
        is_map(ExpressionAttributeValues) ->
     #{ <<"TableName">> => TableName,
        <<"ConditionalExpression">> => ConditionalExpression,
-       <<"ExpressionAttributeNames">> => to_ddb(ExpressionAttributeNames),
+       <<"ExpressionAttributeNames">> => ExpressionAttributeNames,
        <<"ExpressionAttributeValues">> => to_ddb(ExpressionAttributeValues),
        <<"Item">> => to_ddb(Item) }.
 
@@ -886,7 +886,7 @@ make_put_request_test() ->
     Expected = #{<<"ConditionalExpression">> =>
                      <<"#version = :old_version OR attribute_not_exists(#version)">>,
                  <<"ExpressionAttributeNames">> =>
-                     #{<<"#version">> => #{<<"S">> => <<"Version">>}},
+                     #{<<"#version">> => <<"Version">>},
                  <<"ExpressionAttributeValues">> =>
                      #{<<":old_version">> =>
                            #{<<"S">> => <<"totally_a_uuid">>}},

--- a/src/darcy.erl
+++ b/src/darcy.erl
@@ -39,6 +39,7 @@
     get_item/3,
     batch_get_items/3,
     put_item/3,
+    put_item/4,
     batch_write_items/3,
     query/3,
     query/4,
@@ -387,17 +388,47 @@ batch_get_results(TableName, Responses) ->
 
 %% PUT ITEM
 
+%% @doc Put a single item into the given dynamo table, with conditions!
+-spec put_item( Client :: darcy_client:aws_client(),
+                TableName :: binary(),
+                Item :: map(),
+                ConditionMap :: map() ) -> ok | {error, Error :: term()}.
+put_item(Client, TableName, Item, ConditionMap) ->
+    ConditionalExpression = maps:get(condition_expression, ConditionMap, undefined),
+    ExpressionAttributeNames = maps:get(expression_attribute_names, ConditionMap, undefined),
+    ExpressionAttributeValues = maps:get(expression_attribute_values, ConditionMap, undefined),
+    Request = make_put_request(TableName,
+                               Item,
+                               ConditionalExpression,
+                               ExpressionAttributeNames,
+                               ExpressionAttributeValues),
+    case darcy_ddb_api:put_item(Client, Request) of
+         {ok, #{}, {200, _Headers, _Client}} -> ok;
+    {error, Error, {Code, Headers, _Client}} -> {error, {Error, [Code, Headers]}}
+    end.
+
+make_put_request(TableName, Item, undefined, undefined, undefined) ->
+    #{ <<"TableName">> => TableName,
+       <<"Item">> => to_ddb(Item) };
+make_put_request(TableName, Item,
+                 ConditionalExpression,
+                 ExpressionAttributeNames,
+                 ExpressionAttributeValues)
+  when is_binary(ConditionalExpression) and
+       is_map(ExpressionAttributeNames) and
+       is_map(ExpressionAttributeValues) ->
+    #{ <<"TableName">> => TableName,
+       <<"ConditionalExpression">> => ConditionalExpression,
+       <<"ExpressionAttributeNames">> => to_ddb(ExpressionAttributeNames),
+       <<"ExpressionAttributeValues">> => to_ddb(ExpressionAttributeValues),
+       <<"Item">> => to_ddb(Item) }.
+
 %% @doc Put a single item into the given dynamo table.
 -spec put_item( Client :: darcy_client:aws_client(),
                 TableName :: binary(),
                 Item :: map() ) -> ok | {error, Error :: term()}.
 put_item(Client, TableName, Item) ->
-    Request = #{ <<"TableName">> => TableName,
-                 <<"Item">> => to_ddb(Item) },
-    case darcy_ddb_api:put_item(Client, Request) of
-         {ok, #{}, {200, _Headers, _Client}} -> ok;
-    {error, Error, {Code, Headers, _Client}} -> {error, {Error, [Code, Headers]}}
-    end.
+    put_item(Client, TableName, Item, #{}).
 
 %% @doc Put a list of items into the given Dynamo table.
 %%
@@ -838,6 +869,32 @@ gather([W|R], TaskID, Timeout, TimeoutError) ->
 %% Tests
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+
+make_put_request_test() ->
+    TableName = <<"foo">>,
+    Item = #{ <<"Student">> => <<"Foo">>,
+              <<"Version">> => <<"totally_a_uuid">>
+            },
+    ConditionalExpression = <<"#version = :old_version OR attribute_not_exists(#version)">>,
+    ExpressionAttributeNames = #{<<"#version">> => <<"Version">>},
+    ExpressionAttributeValues = #{<<":old_version">> => <<"totally_a_uuid">>},
+
+    Request = make_put_request(TableName, Item,
+                               ConditionalExpression,
+                               ExpressionAttributeNames,
+                               ExpressionAttributeValues),
+    Expected = #{<<"ConditionalExpression">> =>
+                     <<"#version = :old_version OR attribute_not_exists(#version)">>,
+                 <<"ExpressionAttributeNames">> =>
+                     #{<<"#version">> => #{<<"S">> => <<"Version">>}},
+                 <<"ExpressionAttributeValues">> =>
+                     #{<<":old_version">> =>
+                           #{<<"S">> => <<"totally_a_uuid">>}},
+                 <<"Item">> =>
+                     #{<<"Student">> => #{<<"S">> => <<"Foo">>},
+                       <<"Version">> => #{<<"S">> => <<"totally_a_uuid">>}},
+                 <<"TableName">> => <<"foo">>},
+    ?assertEqual(Expected, Request).
 
 to_ddb_test() ->
     Raw = #{ <<"Grades">> => {list, [17,39,76,27]},

--- a/src/darcy.erl
+++ b/src/darcy.erl
@@ -394,12 +394,12 @@ batch_get_results(TableName, Responses) ->
                 Item :: map(),
                 ConditionMap :: map() ) -> ok | {error, Error :: term()}.
 put_item(Client, TableName, Item, ConditionMap) ->
-    ConditionalExpression = maps:get(condition_expression, ConditionMap, undefined),
+    ConditionExpression = maps:get(condition_expression, ConditionMap, undefined),
     ExpressionAttributeNames = maps:get(expression_attribute_names, ConditionMap, undefined),
     ExpressionAttributeValues = maps:get(expression_attribute_values, ConditionMap, undefined),
     Request = make_put_request(TableName,
                                Item,
-                               ConditionalExpression,
+                               ConditionExpression,
                                ExpressionAttributeNames,
                                ExpressionAttributeValues),
     case darcy_ddb_api:put_item(Client, Request) of
@@ -411,14 +411,14 @@ make_put_request(TableName, Item, undefined, undefined, undefined) ->
     #{ <<"TableName">> => TableName,
        <<"Item">> => to_ddb(Item) };
 make_put_request(TableName, Item,
-                 ConditionalExpression,
+                 ConditionExpression,
                  ExpressionAttributeNames,
                  ExpressionAttributeValues)
-  when is_binary(ConditionalExpression) and
+  when is_binary(ConditionExpression) and
        is_map(ExpressionAttributeNames) and
        is_map(ExpressionAttributeValues) ->
     #{ <<"TableName">> => TableName,
-       <<"ConditionalExpression">> => ConditionalExpression,
+       <<"ConditionExpression">> => ConditionExpression,
        <<"ExpressionAttributeNames">> => ExpressionAttributeNames,
        <<"ExpressionAttributeValues">> => to_ddb(ExpressionAttributeValues),
        <<"Item">> => to_ddb(Item) }.
@@ -875,15 +875,15 @@ make_put_request_test() ->
     Item = #{ <<"Student">> => <<"Foo">>,
               <<"Version">> => <<"totally_a_uuid">>
             },
-    ConditionalExpression = <<"#version = :old_version OR attribute_not_exists(#version)">>,
+    ConditionExpression = <<"#version = :old_version OR attribute_not_exists(#version)">>,
     ExpressionAttributeNames = #{<<"#version">> => <<"Version">>},
     ExpressionAttributeValues = #{<<":old_version">> => <<"totally_a_uuid">>},
 
     Request = make_put_request(TableName, Item,
-                               ConditionalExpression,
+                               ConditionExpression,
                                ExpressionAttributeNames,
                                ExpressionAttributeValues),
-    Expected = #{<<"ConditionalExpression">> =>
+    Expected = #{<<"ConditionExpression">> =>
                      <<"#version = :old_version OR attribute_not_exists(#version)">>,
                  <<"ExpressionAttributeNames">> =>
                      #{<<"#version">> => <<"Version">>},

--- a/test/darcy_test.erl
+++ b/test/darcy_test.erl
@@ -73,6 +73,40 @@ make_random_query(Records) ->
        <<"ExpressionAttributeValues">> => EV },
      find_student(Name, Records)}.
 
+cas_test() ->
+    _ = darcy:start(),
+    Client = darcy_client:make_local_client(<<"access">>, <<"secret">>, <<"12000">>),
+    Attributes = [{ <<"Student">>, <<"S">> }, { <<"Subject">>, <<"S">> }],
+    Keys = [<<"Student">>, <<"Subject">>],
+    TableId = make_table_name(),
+    TableSpec = darcy:make_table_spec(TableId, Attributes, Keys),
+    ok = darcy:make_table_if_not_exists(Client, TableSpec),
+
+    GradesV1 = #{ <<"Student">> => <<"Foo">>,
+                  <<"Subject">> => <<"Bar">>,
+                  <<"Grades">> => {list, [75,80,90]},
+                  <<"Average">> => 81.66666666666667,
+                  <<"Version">> => <<"totally_a_uuid">>
+                },
+    ok = darcy:put_item(Client, TableId, GradesV1),
+
+    GradesV2 = #{ <<"Student">> => <<"Foo">>,
+                  <<"Subject">> => <<"Bar">>,
+                  <<"Grades">> => {list, [75,80,90]},
+                  <<"Average">> => 81.66666666666667,
+                  <<"Version">> => <<"the_new_uuid">>
+                },
+    ConditionMap = #{condition_expression => <<"#version = :old_version OR attribute_not_exists(#version)">>,
+                     expression_attribute_names => #{<<"#version">> => <<"Version">>},
+                     expression_attribute_values => #{<<":old_version">> => <<"totally_a_uuid">>}},
+    ok = darcy:put_item(Client, TableId, GradesV2, ConditionMap),
+
+    {ok, Result} = darcy:get_item(Client, TableId, #{ <<"Student">> => <<"Foo">>,
+                                                      <<"Subject">> => <<"Bar">> }),
+    ?assertEqual(ok, Result),
+
+    _ = darcy:delete_table(Client, TableId).
+
 batch_test() ->
     _ = darcy:start(),
     Client = darcy_client:make_local_client(<<"access">>, <<"secret">>, <<"12000">>),
@@ -166,4 +200,3 @@ scan_test() ->
 
     %% gives "ACTIVE" status instead of "DELETING"
     _ = darcy:delete_table(Client, Tid).
-

--- a/test/darcy_test.erl
+++ b/test/darcy_test.erl
@@ -98,7 +98,8 @@ cas_test() ->
                 },
     ConditionMap = #{condition_expression => <<"#version = :old_version OR attribute_not_exists(#version)">>,
                      expression_attribute_names => #{<<"#version">> => <<"Version">>},
-                     expression_attribute_values => #{<<":old_version">> => <<"totally_a_uuid">>}},
+                     expression_attribute_values => #{<<":old_version">> => <<"totally_a_uuid">>}
+                    },
     ok = darcy:put_item(Client, TableId, GradesV2, ConditionMap),
 
     {ok, Result} = darcy:get_item(Client, TableId, #{ <<"Student">> => <<"Foo">>,

--- a/test/darcy_test.erl
+++ b/test/darcy_test.erl
@@ -73,7 +73,7 @@ make_random_query(Records) ->
        <<"ExpressionAttributeValues">> => EV },
      find_student(Name, Records)}.
 
-cas_test() ->
+cas_success_test() ->
     _ = darcy:start(),
     Client = darcy_client:make_local_client(<<"access">>, <<"secret">>, <<"12000">>),
     Attributes = [{ <<"Student">>, <<"S">> }, { <<"Subject">>, <<"S">> }],
@@ -93,7 +93,7 @@ cas_test() ->
     GradesV2 = #{ <<"Student">> => <<"Foo">>,
                   <<"Subject">> => <<"Bar">>,
                   <<"Grades">> => {list, [75,80,90]},
-                  <<"Average">> => 81.66666666666667,
+                  <<"Average">> => 90.0,
                   <<"Version">> => <<"the_new_uuid">>
                 },
     ConditionMap = #{condition_expression => <<"#version = :old_version OR attribute_not_exists(#version)">>,
@@ -104,7 +104,43 @@ cas_test() ->
 
     {ok, Result} = darcy:get_item(Client, TableId, #{ <<"Student">> => <<"Foo">>,
                                                       <<"Subject">> => <<"Bar">> }),
-    ?assertEqual(ok, Result),
+    Expected = #{<<"Average">> => 90,
+                 <<"Grades">> => "KPZ",
+                 <<"Student">> => <<"Foo">>,
+                 <<"Subject">> => <<"Bar">>,
+                 <<"Version">> => <<"the_new_uuid">>},
+    ?assertEqual(Expected, Result),
+
+    _ = darcy:delete_table(Client, TableId).
+
+cas_failure_test() ->
+    _ = darcy:start(),
+    Client = darcy_client:make_local_client(<<"access">>, <<"secret">>, <<"12000">>),
+    Attributes = [{ <<"Student">>, <<"S">> }, { <<"Subject">>, <<"S">> }],
+    Keys = [<<"Student">>, <<"Subject">>],
+    TableId = make_table_name(),
+    TableSpec = darcy:make_table_spec(TableId, Attributes, Keys),
+    ok = darcy:make_table_if_not_exists(Client, TableSpec),
+
+    GradesV1 = #{ <<"Student">> => <<"Foo">>,
+                  <<"Subject">> => <<"Bar">>,
+                  <<"Grades">> => {list, [75,80,90]},
+                  <<"Average">> => 81.66666666666667,
+                  <<"Version">> => <<"totally_a_uuid">>
+                },
+    ok = darcy:put_item(Client, TableId, GradesV1),
+
+    GradesV2 = #{ <<"Student">> => <<"Foo">>,
+                  <<"Subject">> => <<"Bar">>,
+                  <<"Grades">> => {list, [75,80,90]},
+                  <<"Average">> => 90.0,
+                  <<"Version">> => <<"the_new_uuid">>
+                },
+    ConditionMap = #{condition_expression => <<"#version = :old_version OR attribute_not_exists(#version)">>,
+                     expression_attribute_names => #{<<"#version">> => <<"Version">>},
+                     expression_attribute_values => #{<<":old_version">> => <<"not_the_same">>}
+                    },
+    {error, {{_, <<"The conditional request failed">>}, _}} = darcy:put_item(Client, TableId, GradesV2, ConditionMap),
 
     _ = darcy:delete_table(Client, TableId).
 


### PR DESCRIPTION
This pull request extends the put_item call to allow for ConditionExpression and related attributes in said call. This allows for compare-and-swap operations, which is tested for explicitly in the darcy_test suite. 

Resolves #2 