### PR TITLE
Exponential backoff throttle for scan operations

### DIFF
--- a/src/darcy.erl
+++ b/src/darcy.erl
@@ -14,6 +14,8 @@
 -define(BIG_TIMEOUT, 5*60*1000). % 5 minutes
 -define(BATCH_SIZE, 100). % how many items to split into a batch
 -define(BATCH_MAX, 10). % maximum number of batches to process in a single go
+-define(INITIAL_SCAN_ERROR_DELAY, 1000). % initial throughput retry delay in milliseconds
+-define(MAX_ERROR_DELAY, 30000). % maximum millseconds of delay before terminating operation
 
 -export([
     start/0,
@@ -581,18 +583,34 @@ same(X) -> X.
                                           {error, { Reason :: term(), Acc :: [ map() ]}}.
 scan_all(Client, TableName, Expr, Fun) ->
     Request = make_scan_request([Expr, table_name(TableName)]),
-    do_scan_all(Client, Request, execute_scan(Client, Request), Fun, []).
+    do_scan_all(Client, Request, execute_scan(Client, Request), Fun, [], ?INITIAL_SCAN_ERROR_DELAY).
 
-do_scan_all(_Client, _Req, {ok, empty_table}, _Fun, _Acc) -> {ok, []};
-do_scan_all(_Client, _Req, {ok, no_results}, _Fun, Acc) -> {ok, flatten(Acc)};
-do_scan_all(_Client, _Req, {ok, #{ <<"Items">> := I }}, Fun, Acc) ->
+do_scan_all(_Client, _Req, {ok, empty_table}, _Fun, _Acc, _ErrDelay) -> {ok, []};
+do_scan_all(_Client, _Req, {ok, no_results}, _Fun, Acc, _ErrDelay) -> {ok, flatten(Acc)};
+do_scan_all(_Client, _Req, {ok, #{ <<"Items">> := I }}, Fun, Acc, _ErrDelay) ->
     {ok, flatten([ batch_pmap(Fun, I) | Acc ])};
-do_scan_all(_Client, Req, {error, Error}, _Fun, Acc) ->
-    error_logger:error_msg("Error executing scan_all. request: ~p, error: ~p", [Req, Error]),
+
+do_scan_all(_Client, Req, {error, Error}, _Fun, Acc, ErrDelay) when ErrDelay > ?MAX_ERROR_DELAY ->
+    error_logger:error_msg("Error: ~p, request: ~p. Operation has exceeded maximum error delay, terminating...", [Error, Req]),
     {error, {Error, Acc}};
-do_scan_all(Client, Req, {partial, #{ <<"LastEvaluatedKey">> := LEK, <<"Items">> := I }}, Fun, Acc) ->
+
+%% TODO: Seems like we should be able to implement this more cleanly, but
+%% good ideas on how to do so elude me at the moment.
+do_scan_all(Client, Req, {error, {EType, _ETxt}=Error}, Fun, Acc, ErrDelay) ->
+    [_, Exception] = binary:split(<<"#">>, EType),
+    case Exception of
+      <<"ProvisionedThroughputExceededException">> ->
+        error_logger:warning_msg("WARNING: ~p. Pid ~p sleeping for ~p ms, and retrying request...", [Error, self(), ErrDelay]),
+        timer:sleep(ErrDelay),
+        do_scan_all(Client, Req, execute_scan(Client, Req), Fun, Acc, ErrDelay*2);
+      _ ->
+        error_logger:error_msg("Error executing scan_all: ~p request: ~p", [Error, Req]),
+        {error, {Error, Acc}}
+    end;
+
+do_scan_all(Client, Req, {partial, #{ <<"LastEvaluatedKey">> := LEK, <<"Items">> := I }}, Fun, Acc, ErrDelay) ->
     NewRequest = make_scan_request([Req, #{ <<"ExclusiveStartKey">> => LEK }]),
-    do_scan_all(Client, NewRequest, execute_scan(Client, NewRequest), Fun, [ batch_pmap(Fun, I) | Acc]).
+    do_scan_all(Client, NewRequest, execute_scan(Client, NewRequest), Fun, [ batch_pmap(Fun, I) | Acc], ErrDelay).
 
 %% @doc Scan a table in parallel using the given expression. This
 %% function is equivalent to `scan_parallel/7' with a timeout value of 60000
@@ -670,7 +688,7 @@ make_reply_msg(_Ref, Results) ->
     {lists:flatten([ R || {ok, R} <- Res ]), Err}.
 
 worker_scan_all(Client, Request, Fun) ->
-     do_scan_all(Client, Request, execute_scan(Client, Request), Fun, []).
+     do_scan_all(Client, Request, execute_scan(Client, Request), Fun, [], ?INITIAL_SCAN_ERROR_DELAY).
 
 make_segments(N, Count) ->
     #{ <<"Segment">> => N,

--- a/src/darcy.erl
+++ b/src/darcy.erl
@@ -18,9 +18,11 @@
 -define(MAX_ERROR_DELAY, 32000). % maximum millseconds of delay before terminating operation
 -define(INITIAL_ERROR_STATE, #error_delay{}).
 
+%% This is a record because, later, I might try to extend this to reduce the sleep
+%% time based on the number of successful operations. So for now it only has one
+%% field, but it may have two or more in the future.
 -record(error_delay, {
-          delay = 0 :: non_neg_integer(),
-          success = 0 :: non_neg_integer()
+          delay = 0 :: non_neg_integer()
 }).
 
 -export([

--- a/src/darcy_request.erl
+++ b/src/darcy_request.erl
@@ -150,8 +150,8 @@ signed_header({Name, _}) ->
 -include_lib("eunit/include/eunit.hrl").
 
 crypto_lib_info_test() ->
-    ?debugFmt("~p", [crypto:info_lib()]),
-    ?debugFmt("~p", [os:cmd("ldd " ++ code:priv_dir(crypto) ++ "/lib/crypto.so"))])
+    ?debugFmt("Crypto info~n~p~n", [crypto:info_lib()]),
+    ?debugFmt("~n~p~n", [os:cmd("ldd " ++ code:priv_dir(crypto) ++ "/lib/crypto.so")]),
     ok.
 
 %% sign_request/5 extracts credentials, service and region information from

--- a/src/darcy_request.erl
+++ b/src/darcy_request.erl
@@ -149,6 +149,11 @@ signed_header({Name, _}) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
+crypto_lib_info_test() ->
+    ?debugFmt("~p", [crypto:info_lib()]),
+    ?debugFmt("~p", [os:cmd("ldd " ++ code:priv_dir(crypto) ++ "/lib/crypto.so"))])
+    ok.
+
 %% sign_request/5 extracts credentials, service and region information from
 %% a client map and generates an AWS signature version 4 for a request.  It
 %% returns a new set of HTTP headers with Authorization and X-Aws-Date


### PR DESCRIPTION
Scans can take up a tremendous amount of read units.

This commit implements a simple exponential backoff/retry pattern for the scan operations when it encounters the dreaded "ProvisionedThroughputExceededException" instead of throwing up its hands and passing the mess back to the caller.