### PR TITLE
support differnet hostnames for local client

### DIFF
--- a/src/darcy_client.erl
+++ b/src/darcy_client.erl
@@ -2,7 +2,8 @@
 
 -export([make_client/3, make_temporary_client/4,
          switch_region/2,
-	 make_local_client/3]).
+         make_local_client/3,
+         make_local_client/4]).
 
 -type access_key_id() :: binary().
 -type secret_access_key() :: binary().
@@ -56,6 +57,18 @@ make_local_client(AccessKeyID, SecretAccessKey, Port)
     #{access_key_id => AccessKeyID,
       secret_access_key => SecretAccessKey,
       region => <<"local">>,
+      proto => <<"http">>,
+      port => Port,
+      service => undefined}.
+
+-spec make_local_client(access_key_id(), secret_access_key(), binary(), http_port()) ->
+			       aws_client().
+make_local_client(AccessKeyID, SecretAccessKey, Host, Port)
+  when is_binary(AccessKeyID), is_binary(SecretAccessKey), is_binary(Port) ->
+    #{access_key_id => AccessKeyID,
+      secret_access_key => SecretAccessKey,
+      region => <<"local">>,
+      endpoint => Host,
       proto => <<"http">>,
       port => Port,
       service => undefined}.

--- a/src/darcy_ddb_api.erl
+++ b/src/darcy_ddb_api.erl
@@ -1123,6 +1123,8 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
+get_host(_EndpointPrefix, #{region := <<"local">>, endpoint := Endpoint}) ->
+    Endpoint;
 get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
 get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->


### PR DESCRIPTION
This patch adds support for setting the host to use for a "local" client instead of requiring localhost. This is required for using amazon's dynamo-local docker image in cases it can't be available on `localhost` but is on another hostname.